### PR TITLE
feat: Update Docker images, Node once per month; only rebase on conflict

### DIFF
--- a/default.json
+++ b/default.json
@@ -64,6 +64,19 @@
       "schedule": ["* 0-9 1,15 * *"]
     },
     {
+      "description": "Schedule Docker image updates monthly on 1st (12am-9am)",
+      "matchDatasources": ["docker"],
+      "schedule": ["* 0-9 1 * *"],
+      "automerge": false
+    },
+    {
+      "description": "Schedule Node.js updates monthly on 1st (12am-9am)",
+      "matchPackageNames": ["node", "nodejs", "@types/node"],
+      "matchDatasources": ["node-version", "npm"],
+      "schedule": ["* 0-9 1 * *"],
+      "automerge": false
+    },
+    {
       "groupName": "motion-dependencies",
       "matchPackageNames": ["framer-motion", "motion"],
       "automerge": false

--- a/default.json
+++ b/default.json
@@ -1,5 +1,6 @@
 {
   "automerge": false,
+  "rebaseWhen": "conflicted",
   "commitMessagePrefix": "chore(deps): ",
   "extends": [
     "config:best-practices",

--- a/default.json
+++ b/default.json
@@ -72,7 +72,7 @@
     {
       "description": "Schedule Node.js updates monthly on 1st (12am-9am)",
       "matchPackageNames": ["node", "nodejs", "@types/node"],
-      "matchDatasources": ["node-version", "npm"],
+      "matchDatasources": ["node-version", "npm", "docker"],
       "schedule": ["* 0-9 1 * *"],
       "automerge": false
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new scheduling rules for Docker image and Node.js package updates, setting them to run monthly on the 1st day between midnight and 9am, without automerging.
  * Updates will now only be rebased if conflicts occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->