### PR TITLE
feat: Automerge codecov, actions/checkout, uv Github action updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -83,9 +83,10 @@
       "automerge": false
     },
     {
-      "description": "Automerge github actions",
-      "matchDatasources": ["github-actions"],
+      "description": "Automerge GitHub Actions",
+      "matchManagers": ["github-actions"],
       "matchPackageNames": ["codecov/codecov-action", "actions/checkout"],
+      "matchUpdateTypes": ["patch", "minor"],
       "automerge": true
     },
     {

--- a/default.json
+++ b/default.json
@@ -83,8 +83,8 @@
       "automerge": false
     },
     {
-      "description": "Automerge docker images",
-      "matchDatasources": ["docker"],
+      "description": "Automerge github actions",
+      "matchDatasources": ["github-actions"],
       "matchPackageNames": ["codecov/codecov-action"],
       "automerge": true
     },

--- a/default.json
+++ b/default.json
@@ -83,6 +83,13 @@
       "automerge": false
     },
     {
+      "description": "Automerge docker images",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["codecov/codecov-action"],
+      "automerge": true
+    },
+    {
+      "description": "Automerge devDependencies",
       "matchDepTypes": ["devDependencies"],
       "matchPackageNames": [
         "@babel/*",

--- a/default.json
+++ b/default.json
@@ -85,7 +85,7 @@
     {
       "description": "Automerge github actions",
       "matchDatasources": ["github-actions"],
-      "matchPackageNames": ["codecov/codecov-action"],
+      "matchPackageNames": ["codecov/codecov-action", "actions/checkout"],
       "automerge": true
     },
     {

--- a/default.json
+++ b/default.json
@@ -85,7 +85,7 @@
     {
       "description": "Automerge GitHub Actions",
       "matchManagers": ["github-actions"],
-      "matchPackageNames": ["codecov/codecov-action", "actions/checkout"],
+      "matchPackageNames": ["codecov/codecov-action", "actions/checkout", "astral-sh/setup-uv"],
       "matchUpdateTypes": ["patch", "minor"],
       "automerge": true
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated maintenance rules to auto-merge safe updates for selected development dependencies (linters, types, testing, build tools) to reduce PR noise and keep tooling current.
  * Enabled auto-merge for a specific CI action update to streamline continuous integration upkeep.
  * No user-facing changes; runtime behavior and features remain unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->